### PR TITLE
SVC-3240: Fix discovered issues with openldap config

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -84,8 +84,8 @@ profile_system_auth::kerberos::crons:
 profile_system_auth::kerberos::root_k5login_principals: null
 profile_system_auth::ldap::ldap_conf: |
   # This file is managed by Puppet.
-  TLS_CACERTDIR   /etc/pki/tls/certs
   TLS_REQCERT     demand
   BASE            dc=ncsa,dc=illinois,dc=edu
-  URI             ldaps://ldap1.ncsa.illinois.edu ldaps://ldap2.ncsa.illinois.edu
+  URI             ldaps://ldap1.ncsa.illinois.edu ldaps://ldap2.ncsa.illinois.edu ldaps://ldap3.ncsa.illinois.edu ldaps://ldap4.ncsa.illinois.edu
   SASL_NOCANON    on
+  SSL             yes

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -12,5 +12,12 @@ profile_system_auth::kerberos::files_remove_setuid:
 profile_system_auth::kerberos::required_pkgs:
   - "krb5-libs"
   - "krb5-workstation"
+profile_system_auth::ldap::ldap_conf: |
+  # This file is managed by Puppet.
+  TLS_REQCERT     demand
+  BASE            dc=ncsa,dc=illinois,dc=edu
+  URI             ldaps://ldap1.ncsa.illinois.edu ldaps://ldap2.ncsa.illinois.edu ldaps://ldap3.ncsa.illinois.edu ldaps://ldap4.ncsa.illinois.edu
+  SASL_NOCANON    on
+  SSL             yes
 profile_system_auth::ldap::required_pkgs:
   - "openldap-clients"

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -5,3 +5,11 @@ profile_system_auth::config::required_pkgs:
   - "oddjob"
   - "oddjob-mkhomedir"
 profile_system_auth::config::use_authconfig: true
+profile_system_auth::ldap::ldap_conf: |
+  # This file is managed by Puppet.
+  TLS_CACERTDIR   /etc/pki/tls/certs
+  TLS_REQCERT     demand
+  BASE            dc=ncsa,dc=illinois,dc=edu
+  URI             ldaps://ldap1.ncsa.illinois.edu ldaps://ldap2.ncsa.illinois.edu ldaps://ldap3.ncsa.illinois.edu ldaps://ldap4.ncsa.illinois.edu
+  SASL_NOCANON    on
+  SSL             yes


### PR DESCRIPTION
Update openldap conf certs to work with RHEL8
Update openldap conf to use all NCSA ldap replicas
Update openldap conf to specifically use ssl
Fix openldap conf yaml warnings

This is being tested on the following hosts:
- `asd-test-centos7a`
- `asd-test-rhel8b`
- `asd-test-web2`
- `users`

It can be tested by running a command like the following as any user on these hosts:
```
ldapsearch -x '(cn=all_ncsa_employe)' | grep uniqueMember | head
```