### PR TITLE
Svc 7630 debug nokrb5

### DIFF
--- a/files/root/createhostkeytab.sh
+++ b/files/root/createhostkeytab.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 RANDSTRING=`head -c 16 /dev/random  | base64 | grep -o . | sort -R | tr -d "\n" | head -c 14`
 REQCLASS1=`date | base64 | tr -dc A-Z | grep -o . | sort -R | tr -d "\n" | head -c2`
 REQCLASS2=`date | base64 | tr -dc a-z | grep -o . | sort -R | tr -d "\n" | head -c2`

--- a/manifests/kerberos.pp
+++ b/manifests/kerberos.pp
@@ -91,7 +91,7 @@ class profile_system_auth::kerberos (
     $vault_uri = profile_secrets::lookup_uri($vaultsecretdir)
     $vault_auth = lookup(profile_secrets::vault_authmethod)
     $vault_kv_version = lookup(profile_secrets::vault_kv_version)
-    $createhostkeytabbase64 = Sensitive(vault_key($vault_uri,$vault_auth,$vaultkeytabkey,$vault_kv_version))
+    $createhostkeytabbase64 = vault_key($vault_uri,$vault_auth,$vaultkeytabkey,$vault_kv_version)
   }
   else
   {


### PR DESCRIPTION
The script the creates the krb5.keytab will exit with an error if any command fails. I also removed the sensitive from the vault_key lookup as it wasn't actually retrieving the secret properly. This need more investigation, but this gets things working.