### PR TITLE
SVCPLAN-5143: Have kerberos use persistent keyring for ccache

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -27,7 +27,6 @@ profile_system_auth::config::oddjobd_mkhomedir_conf: |
   </oddjobconfig>
 profile_system_auth::config::pam_config: {}
 
-
 profile_system_auth::kerberos::ad_computers_ou: null
 profile_system_auth::kerberos::ad_createhostkeytab: null
 profile_system_auth::kerberos::ad_createhostuser: null


### PR DESCRIPTION
I have Puppet set to hard code changing the Kerberos `default_ccache_name` to be `KEYRING:persistent:%{uid}` instead of `KCM:`.

I had originally tried to set the `default_ccache_name` value via a parameter that could be overridden. But something about the string `:%{` ends up being converted to some sort of variable via YAML and/or Puppet. I never could find the correct combination of delimited characters to get past that issue. So the value is now set statically in the Puppet manifest directly.

This has been tested on `control-test-opensuse155a`, `control-test-rhel7b`, `control-test-rhel8b`, & `control-test-rhel9b`.

Once this is merged, #26 is now no longer relevant and can be closed as not being needed.