### PR TITLE
SVCPLAN-7581: manage default_ccache_file as a file

### DIFF
--- a/manifests/kerberos.pp
+++ b/manifests/kerberos.pp
@@ -90,6 +90,10 @@ class profile_system_auth::kerberos (
 
     # SVCPLAN-5143: use KEYRING ccache instead of KCM
     $default_ccache_file = '/etc/krb5.conf.d/kcm_default_ccache'
+    file { $default_ccache_file:
+      ensure => file,
+      mode   => '0644',
+    }
     $puppet_file_header = '# This file is managed by Puppet.'
     exec { "add puppet header to ${default_ccache_file}":
       command => "sed -i '1s/^/${puppet_file_header}\\n/' '${default_ccache_file}'",


### PR DESCRIPTION
Ensure it exists prior to adding settings, and ensure appropriate permissions.

This fixes things on DeltaAI where the file doesn't exist (due to SLES OS?) and where the root umask of 0077 causes it to not be readable by non-root users when it is created.