### PR TITLE
SECURITY-1799: Enable authselect features

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -42,6 +42,7 @@ include profile_system_auth::config
 
 The following parameters are available in the `profile_system_auth::config` class:
 
+* [`authselect_features`](#-profile_system_auth--config--authselect_features)
 * [`authselect_profile`](#-profile_system_auth--config--authselect_profile)
 * [`enable_mkhomedir`](#-profile_system_auth--config--enable_mkhomedir)
 * [`oddjobd_mkhomedir_conf`](#-profile_system_auth--config--oddjobd_mkhomedir_conf)
@@ -50,12 +51,18 @@ The following parameters are available in the `profile_system_auth::config` clas
 * [`required_pkgs`](#-profile_system_auth--config--required_pkgs)
 * [`use_authconfig`](#-profile_system_auth--config--use_authconfig)
 
+##### <a name="-profile_system_auth--config--authselect_features"></a>`authselect_features`
+
+Data type: `Array[String[1]]`
+
+Array of authselect features to enable
+
 ##### <a name="-profile_system_auth--config--authselect_profile"></a>`authselect_profile`
 
 Data type: `String`
 
 String of authselect profile
-Valid only for >= RHEL8
+Valid only for >= RHEL8 and SUSE
 
 ##### <a name="-profile_system_auth--config--enable_mkhomedir"></a>`enable_mkhomedir`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,6 @@
 ---
+profile_system_auth::config::authselect_features:
+  - "with-pamaccess"
 profile_system_auth::config::authselect_profile: "sssd"
 profile_system_auth::config::enable_mkhomedir: true
 profile_system_auth::config::oddjobd_mkhomedir_conf: |


### PR DESCRIPTION
Fix #29 

This has been tested on `cc-test[01-02]`.

The actual `exec` is a bit ugly because other modules (e.g. ncsa/profile_hostbased_ssh and ncsa/profile_duo) later make changes to the following 2 files, which then prevents future `authselect` changes because these files have been altered outside of `authselect`:
- `/etc/authselect/system-auth`
- `/etc/authselect/password-auth`

To work around this, I'm forcing `authselect` to reset the profile and then add the feature again.