### PR TITLE
SVCPLAN-9192: Kerberos host principal should match OS hostname

### DIFF
--- a/templates/createhostkeytab.sh.erb
+++ b/templates/createhostkeytab.sh.erb
@@ -6,11 +6,11 @@ set -x
 
 # ASSIGN ARGUMENTS FROM COMMAND LINE ARGUMENTS
 CREATEHOST_USER=$2  # User with permissions to create host in AD
-DOMAIN=$3           # KERBEROS DOMAIN
+KRB_DOMAIN=$3       # KERBEROS DOMAIN
 KEYTAB_BASE64=$1    # Base64 encoded keytab for creating host
 
 # ASSIGN STATIC VARIABLES
-HOST_FQDN="<%= @fqdn %>"  # Fully Qualified Domain Name of the host
+HOST_FQDN=`hostname -f`  # FQDN according to the host
 KEYTAB_FILE="/root/createhost.keytab"  # Path to store the decoded keytab file
 
 RANDSTRING=`head -c 16 /dev/random  | base64 | grep -o . | sort -R | tr -d "\n" | head -c 14`
@@ -23,8 +23,8 @@ TEMPPASS=`echo "$RANDSTRING$REQCHARS" | grep -o . | sort -R | tr -d "\n"`
 # Decode the base64 encoded keytab and save it to a file
 echo "${KEYTAB_BASE64}" | base64 --decode > $KEYTAB_FILE
 
-echo -e "$TEMPPASS\n$TEMPPASS" | kadmin -kt /root/createhost.keytab -p ${CREATEHOST_USER}/createhost@${DOMAIN} -q "addprinc host/${HOST_FQDN}@${DOMAIN}"
-echo -e "$TEMPPASS" | kadmin -p host/${HOST_FQDN}@${DOMAIN} -q "ktadd host/${HOST_FQDN}@${DOMAIN}"
+echo -e "$TEMPPASS\n$TEMPPASS" | kadmin -kt /root/createhost.keytab -p ${CREATEHOST_USER}/createhost@${KRB_DOMAIN} -q "addprinc host/${HOST_FQDN}@${KRB_DOMAIN}"
+echo -e "$TEMPPASS" | kadmin -p host/${HOST_FQDN}@${KRB_DOMAIN} -q "ktadd host/${HOST_FQDN}@${KRB_DOMAIN}"
 
 # Optionally, list the contents of the keytab file (uncomment for debugging)
 # klist -kte


### PR DESCRIPTION
@fqdn seems to match the Puppet certificate. In some cases this does not match the OS hostname, i.e., `hostname -f`. When creating the host principal, use `@hostname.@domain`, which should more reliably match `hostname -f`.

NOTE: Had to use `scope.lookupvar('::domain')` to ensure we get the *fact* rather than the *class parameter* (which is the Kerberos domain).