### PR TITLE
SVCPLAN-9198: augment PATH for krb5 crons

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -123,6 +123,7 @@ The following parameters are available in the `profile_system_auth::kerberos` cl
 * [`cfg_file_settings`](#-profile_system_auth--kerberos--cfg_file_settings)
 * [`createhostkeytab`](#-profile_system_auth--kerberos--createhostkeytab)
 * [`createhostuser`](#-profile_system_auth--kerberos--createhostuser)
+* [`cron_path_additions`](#-profile_system_auth--kerberos--cron_path_additions)
 * [`crons`](#-profile_system_auth--kerberos--crons)
 * [`domain`](#-profile_system_auth--kerberos--domain)
 * [`enable`](#-profile_system_auth--kerberos--enable)
@@ -171,6 +172,17 @@ Optional String of base64 encoding of krb5 createhost keytab file
 Data type: `Optional[String]`
 
 Optional String of kerberos principal username to be used for kerberos createhost
+
+##### <a name="-profile_system_auth--kerberos--cron_path_additions"></a>`cron_path_additions`
+
+Data type: `Array[String]`
+
+Optional Array of Strings with directories that should be added to the PATH before
+the CRON entries execute. This is to help with OS distros that install Kerberos admin
+commands in locations that aren't on the PATH during CRON execution. It adds this
+as a local PATH override at the beginning of the command in each CRON entry rather
+than as an actual CRON environent variable (which would apply to every subsequent
+CRON entry in that crontab).
 
 ##### <a name="-profile_system_auth--kerberos--crons"></a>`crons`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -34,6 +34,8 @@ profile_system_auth::kerberos::ad_createhostkeytab: null
 profile_system_auth::kerberos::ad_createhostuser: null
 profile_system_auth::kerberos::ad_domain: null
 
+profile_system_auth::kerberos::cron_path_additions: []
+
 profile_system_auth::kerberos::cfg_file_settings:
   /etc/krb5.conf: |
     # This file is managed by Puppet.

--- a/data/os/SLES.yaml
+++ b/data/os/SLES.yaml
@@ -1,0 +1,4 @@
+---
+
+profile_system_auth::kerberos::cron_path_additions:
+  - "/usr/lib/mit/bin"

--- a/manifests/kerberos.pp
+++ b/manifests/kerberos.pp
@@ -23,6 +23,14 @@
 # @param createhostuser
 #   Optional String of kerberos principal username to be used for kerberos createhost
 #
+# @param cron_path_additions
+#   Optional Array of Strings with directories that should be added to the PATH before
+#   the CRON entries execute. This is to help with OS distros that install Kerberos admin
+#   commands in locations that aren't on the PATH during CRON execution. It adds this
+#   as a local PATH override at the beginning of the command in each CRON entry rather
+#   than as an actual CRON environent variable (which would apply to every subsequent
+#   CRON entry in that crontab).
+#
 # @param crons
 #   Hash of cron resource parameters for any CRON entries related to kerberos keytab cleanup
 #
@@ -52,6 +60,7 @@ class profile_system_auth::kerberos (
   Hash             $cfg_file_settings,        # cfg files and their contents
   Optional[String] $createhostkeytab,         # BASE64 ENCODING OF KRB5 CREATEHOST KEYTAB FILE
   Optional[String] $createhostuser,           # CREATEHOST USER
+  Array[String]    $cron_path_additions,
   Hash             $crons,
   Optional[String] $domain,                   # KERBEROS DOMAIN
   Boolean          $enable,
@@ -157,8 +166,29 @@ class profile_system_auth::kerberos (
         minute      => 1,
         environment => ['SHELL=/bin/sh',],
       }
-      $crons.each | $k, $v | {
-        cron { $k: * => $v }
+
+      # Build PATH prefix (or empty string)
+      $path_prefix = $cron_path_additions.empty ? {
+        true  => '',
+        false => "PATH=\"${cron_path_additions.join(':')}:\$PATH\" && ",
+      }
+
+      # Create cron resources
+      $crons.each |$k, $v| {
+        # Extract the base cron command
+        $original_cmd = $v['command']
+
+        # Build new command with optional prefix
+        $new_cmd = "${path_prefix}${original_cmd}"
+
+        # Merge into hash (override command)
+        $cron_params = $v + {
+          'command' => $new_cmd,
+        }
+
+        cron { $k:
+          * => $cron_params,
+        }
       }
     }
     else {


### PR DESCRIPTION
krb5 commands on SLES are in `/usr/lib/mit/bin`, which is not on the default `PATH` during CRON execution.

This update will augment the `PATH` for exection of each CRON on SLES nodes, e.g.:
```bash
30 23 1 * * PATH="/usr/lib/mit/bin:$PATH" && sleep ...
```

This is done instead of applying this `PATH` change as an env var in the crontab (`"PATH=..."` at the beginning of a line, w/o timing info) because that method applies to all subsequent CRONs, which would be hard to manage.

Also note that it's not enough to simply reference each command using its full path -- in particular `k5srvutil` itself calls `kadmin` w/o using its full path.

This will not affect other OS versions (even non-SLES SUSE).